### PR TITLE
feat: add GitHub CLI installer alias

### DIFF
--- a/.devrc
+++ b/.devrc
@@ -846,6 +846,38 @@ installCodexCLI() {
     npm i -g @openai/codex
 }
 
+installGitHub() {
+    if command -v gh >/dev/null 2>&1; then
+        echo "✓ GitHub CLI is already installed: $(gh --version | head -n1)"
+        return 0
+    fi
+
+    if ! command -v apt-get >/dev/null 2>&1; then
+        echo "GitHub CLI install requires apt-get (Debian/Ubuntu)." >&2
+        return 1
+    fi
+
+    local sudo_cmd=""
+    if [ "$(id -u)" -eq 0 ]; then
+        sudo_cmd=""
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo_cmd="sudo"
+    else
+        echo "GitHub CLI install requires sudo." >&2
+        return 1
+    fi
+
+    $sudo_cmd apt-get update && $sudo_cmd apt-get install -y gh || return 1
+
+    if command -v gh >/dev/null 2>&1; then
+        echo "✓ GitHub CLI installed: $(gh --version | head -n1)"
+        return 0
+    fi
+
+    echo "✗ Failed to install GitHub CLI." >&2
+    return 1
+}
+
 installNeovim() {
     if ! command -v apt-get >/dev/null 2>&1; then
         printf '%s\n' "apt-get is required to install Neovim." >&2

--- a/ALIAS
+++ b/ALIAS
@@ -110,6 +110,10 @@ installCodexCLI:
 installcodex
 installcodexcli
 
+installGitHub:
+installgithub
+installgh
+
 installNeovim:
 installneovim
 installlazyvim

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Setup Mobile Workflow
 
 initubuntu
 installnodeenv
+installgithub
 usessh
 cloneuserrepo
 installterraform
@@ -112,6 +113,10 @@ These files act as single sources of truth for file lists. Each manifest file li
 | `ALIAS` | Centralized aliases | `.devrc`, `profile.ps1` |
 
 **To add/remove a file from sync:** Edit the manifest file - scripts pick up changes automatically.
+
+## Handy Commands
+
+- `installgithub` installs the GitHub CLI (`gh`) on Debian/Ubuntu systems.
 
 ### How Syncing Works
 


### PR DESCRIPTION
## Summary
- add an `installGitHub` helper to `.devrc` for installing the GitHub CLI on Debian/Ubuntu systems
- add `installgithub` and `installgh` aliases so the command is available through the shared alias file
- document the new installer in the user repo README and setup flow